### PR TITLE
get accessors instead of fields

### DIFF
--- a/lib/src/class_element.dart
+++ b/lib/src/class_element.dart
@@ -4,7 +4,9 @@ abstract class WithMetadata {
   List<AnnotationElementWrap> get metadata;
 }
 
-class ClassElementWrap extends Object with NamedElement implements WithMetadata {
+class ClassElementWrap extends Object
+    with NamedElement
+    implements WithMetadata {
   final ClassElement _wrapped;
 
   ClassElementWrap(this._wrapped);
@@ -13,8 +15,9 @@ class ClassElementWrap extends Object with NamedElement implements WithMetadata 
 
   String get libraryName => _wrapped.library.name;
 
-  List<InterfaceTypeWrap> get allSupertypes =>
-      _wrapped.allSupertypes.map((InterfaceType iface) => new InterfaceTypeWrap(iface)).toList();
+  List<InterfaceTypeWrap> get allSupertypes => _wrapped.allSupertypes
+      .map((InterfaceType iface) => new InterfaceTypeWrap(iface))
+      .toList();
 
   bool isSameAs(ClassElementWrap other) {
     return name == other.name && libraryName == other.libraryName;
@@ -24,23 +27,29 @@ class ClassElementWrap extends Object with NamedElement implements WithMetadata 
     return first.name == name && first.libraryName == libraryName;
   }
 
-  List<PropertyAccessorElement> get fields {
+  List<FieldElement> get fiels => _wrapped.fields;
+
+  List<PropertyAccessorElement> getAccessors({bool withSupertype: false}) {
     List<PropertyAccessorElement> access = new List.from(_wrapped.accessors);
-    for (InterfaceTypeWrap supertype in allSupertypes) {
-      if (supertype.name != "Object") {
-        access.addAll(supertype.accessors);
+    if (withSupertype == true) {
+      for (InterfaceTypeWrap supertype in allSupertypes) {
+        if (supertype.name != "Object") {
+          //fixme: better way to do this ?
+          access.addAll(supertype.accessors);
+        }
       }
     }
     return access;
   }
 
-  List<AnnotationElementWrap> get metadata =>
-      _wrapped.metadata.map((annot) => new AnnotationElementWrap(annot)).toList();
+  List<AnnotationElementWrap> get metadata => _wrapped.metadata
+      .map((annot) => new AnnotationElementWrap(annot))
+      .toList();
 
   List<TypeParameterElement> get typeParameters => _wrapped.typeParameters;
 
-  bool isSubtypeOf(NamedElement type) =>
-      allSupertypes.any((InterfaceTypeWrap inter) => inter.compareNamedElement(type));
+  bool isSubtypeOf(NamedElement type) => allSupertypes
+      .any((InterfaceTypeWrap inter) => inter.compareNamedElement(type));
 
   InterfaceTypeWrap getSubtypeOf(NamedElement named) {
     for (InterfaceTypeWrap interface in allSupertypes) {
@@ -52,9 +61,11 @@ class ClassElementWrap extends Object with NamedElement implements WithMetadata 
     return null;
   }
 
-  List<MethodElementWrap> get methods => _wrapped.methods.map((meth) => new MethodElementWrap(meth)).toList();
+  List<MethodElementWrap> get methods =>
+      _wrapped.methods.map((meth) => new MethodElementWrap(meth)).toList();
 
-  ConstructorElementWrap get unnamedConstructor => new ConstructorElementWrap(_wrapped.unnamedConstructor);
+  ConstructorElementWrap get unnamedConstructor =>
+      new ConstructorElementWrap(_wrapped.unnamedConstructor);
 
   ConstructorElementWrap getNamedConstructors(String name) {
     ConstructorElement el = _wrapped.getNamedConstructor(name);

--- a/lib/src/class_element.dart
+++ b/lib/src/class_element.dart
@@ -4,9 +4,7 @@ abstract class WithMetadata {
   List<AnnotationElementWrap> get metadata;
 }
 
-class ClassElementWrap extends Object
-    with NamedElement
-    implements WithMetadata {
+class ClassElementWrap extends Object with NamedElement implements WithMetadata {
   final ClassElement _wrapped;
 
   ClassElementWrap(this._wrapped);
@@ -15,9 +13,8 @@ class ClassElementWrap extends Object
 
   String get libraryName => _wrapped.library.name;
 
-  List<InterfaceTypeWrap> get allSupertypes => _wrapped.allSupertypes
-      .map((InterfaceType iface) => new InterfaceTypeWrap(iface))
-      .toList();
+  List<InterfaceTypeWrap> get allSupertypes =>
+      _wrapped.allSupertypes.map((InterfaceType iface) => new InterfaceTypeWrap(iface)).toList();
 
   bool isSameAs(ClassElementWrap other) {
     return name == other.name && libraryName == other.libraryName;
@@ -27,16 +24,23 @@ class ClassElementWrap extends Object
     return first.name == name && first.libraryName == libraryName;
   }
 
-  List<FieldElement> get fields => _wrapped.fields;
+  List<PropertyAccessorElement> get fields {
+    List<PropertyAccessorElement> access = new List.from(_wrapped.accessors);
+    for (InterfaceTypeWrap supertype in allSupertypes) {
+      if (supertype.name != "Object") {
+        access.addAll(supertype.accessors);
+      }
+    }
+    return access;
+  }
 
-  List<AnnotationElementWrap> get metadata => _wrapped.metadata
-      .map((annot) => new AnnotationElementWrap(annot))
-      .toList();
+  List<AnnotationElementWrap> get metadata =>
+      _wrapped.metadata.map((annot) => new AnnotationElementWrap(annot)).toList();
 
   List<TypeParameterElement> get typeParameters => _wrapped.typeParameters;
 
-  bool isSubtypeOf(NamedElement type) => allSupertypes
-      .any((InterfaceTypeWrap inter) => inter.compareNamedElement(type));
+  bool isSubtypeOf(NamedElement type) =>
+      allSupertypes.any((InterfaceTypeWrap inter) => inter.compareNamedElement(type));
 
   InterfaceTypeWrap getSubtypeOf(NamedElement named) {
     for (InterfaceTypeWrap interface in allSupertypes) {
@@ -48,11 +52,9 @@ class ClassElementWrap extends Object
     return null;
   }
 
-  List<MethodElementWrap> get methods =>
-      _wrapped.methods.map((meth) => new MethodElementWrap(meth)).toList();
+  List<MethodElementWrap> get methods => _wrapped.methods.map((meth) => new MethodElementWrap(meth)).toList();
 
-  ConstructorElementWrap get unnamedConstructor =>
-      new ConstructorElementWrap(_wrapped.unnamedConstructor);
+  ConstructorElementWrap get unnamedConstructor => new ConstructorElementWrap(_wrapped.unnamedConstructor);
 
   ConstructorElementWrap getNamedConstructors(String name) {
     ConstructorElement el = _wrapped.getNamedConstructor(name);

--- a/lib/src/class_element.dart
+++ b/lib/src/class_element.dart
@@ -27,7 +27,7 @@ class ClassElementWrap extends Object
     return first.name == name && first.libraryName == libraryName;
   }
 
-  List<FieldElement> get fiels => _wrapped.fields;
+  List<FieldElement> get fields => _wrapped.fields;
 
   List<PropertyAccessorElement> getAccessors({bool withSupertype: false}) {
     List<PropertyAccessorElement> access = new List.from(_wrapped.accessors);

--- a/lib/src/interface_type_element.dart
+++ b/lib/src/interface_type_element.dart
@@ -13,4 +13,6 @@ class InterfaceTypeWrap extends Object with NamedElement {
       _wrapped.typeArguments.map((arg) => new DartTypeWrap(arg)).toList();
 
   List<TypeParameterElement> get typeParameters => _wrapped.typeParameters;
+
+  List<PropertyAccessorElement> get accessors => _wrapped.accessors;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: source_gen_help
 description: Some helpers for source_gen
-version: 0.0.3
+version: 0.0.4
 authors:
 - Ravi Teja Gudapati <tejainece@gmail.com>
 - Kevin Segaud <segaud.kevin@gmail.com>


### PR DESCRIPTION
In ClassWrapper

Get accessors instead of fields, with accessors from superType

Needed to handle inheritance in jaguar_serializer